### PR TITLE
Add float32 and float64

### DIFF
--- a/ServerCodeExciserTest/Problems/Common/DeclarationInFunctionRootScopeWithReturnValTest.common
+++ b/ServerCodeExciserTest/Problems/Common/DeclarationInFunctionRootScopeWithReturnValTest.common
@@ -36,6 +36,26 @@ class UDeclarationInFunctionRootScopeWithReturnValTest
 		return ThisMustBeGuarded;
 	}
 
+	float32 TestFloat32()
+	{
+		ensure(System::IsServer());
+
+		float32 ThisMustBeGuarded = 0.0f;
+		ThisMustBeGuarded--;
+
+		return ThisMustBeGuarded;
+	}
+
+	float64 TestFloat64()
+	{
+		ensure(System::IsServer());
+
+		float64 ThisMustBeGuarded = 0.0f;
+		ThisMustBeGuarded--;
+
+		return ThisMustBeGuarded;
+	}
+
 	FString TestString()
 	{
 		ensure(System::IsServer());

--- a/ServerCodeExciserTest/Solutions/Common/DeclarationInFunctionRootScopeWithReturnValTest.common
+++ b/ServerCodeExciserTest/Solutions/Common/DeclarationInFunctionRootScopeWithReturnValTest.common
@@ -34,7 +34,7 @@ class UDeclarationInFunctionRootScopeWithReturnValTest
 #endif // WITH_SERVER
 	}
 
-	float TestFloat()
+	double TestFloat()
 	{
 		ensure(System::IsServer());
 #ifdef WITH_SERVER
@@ -45,6 +45,34 @@ class UDeclarationInFunctionRootScopeWithReturnValTest
 		return ThisMustBeGuarded;
 #else
 		return 0.0f;
+#endif // WITH_SERVER
+	}
+
+	float32 TestFloat32()
+	{
+		ensure(System::IsServer());
+#ifdef WITH_SERVER
+
+		float32 ThisMustBeGuarded = 0.0f;
+		ThisMustBeGuarded--;
+
+		return ThisMustBeGuarded;
+#else
+		return 0.0f;
+#endif // WITH_SERVER
+	}
+
+	float64 TestFloat64()
+	{
+		ensure(System::IsServer());
+#ifdef WITH_SERVER
+
+		float64 ThisMustBeGuarded = 0.0;
+		ThisMustBeGuarded--;
+
+		return ThisMustBeGuarded;
+#else
+		return 0.0;
 #endif // WITH_SERVER
 	}
 

--- a/ServerCodeExciserTest/Solutions/Common/DeclarationInFunctionRootScopeWithReturnValTest.common
+++ b/ServerCodeExciserTest/Solutions/Common/DeclarationInFunctionRootScopeWithReturnValTest.common
@@ -67,12 +67,12 @@ class UDeclarationInFunctionRootScopeWithReturnValTest
 		ensure(System::IsServer());
 #ifdef WITH_SERVER
 
-		float64 ThisMustBeGuarded = 0.0f;
+		float64 ThisMustBeGuarded = 0.0;
 		ThisMustBeGuarded--;
 
 		return ThisMustBeGuarded;
 #else
-		return 0.0f;
+		return 0.0;
 #endif // WITH_SERVER
 	}
 

--- a/ServerCodeExciserTest/Solutions/Common/DeclarationInFunctionRootScopeWithReturnValTest.common
+++ b/ServerCodeExciserTest/Solutions/Common/DeclarationInFunctionRootScopeWithReturnValTest.common
@@ -34,7 +34,7 @@ class UDeclarationInFunctionRootScopeWithReturnValTest
 #endif // WITH_SERVER
 	}
 
-	double TestFloat()
+	float TestFloat()
 	{
 		ensure(System::IsServer());
 #ifdef WITH_SERVER
@@ -67,12 +67,12 @@ class UDeclarationInFunctionRootScopeWithReturnValTest
 		ensure(System::IsServer());
 #ifdef WITH_SERVER
 
-		float64 ThisMustBeGuarded = 0.0;
+		float64 ThisMustBeGuarded = 0.0f;
 		ThisMustBeGuarded--;
 
 		return ThisMustBeGuarded;
 #else
-		return 0.0;
+		return 0.0f;
 #endif // WITH_SERVER
 	}
 

--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
@@ -71,6 +71,8 @@ UInt16: 'uint16';
 UInt32: 'uint32';
 UInt64: 'uint64';
 Float: 'float';
+Float32: 'float32';
+Float64: 'float64';
 Double: 'double';
 Bool: 'bool';
 

--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
@@ -38,10 +38,10 @@ script:
 annotationList:
 	annotation (Comma annotation)*;
 
-annotation: 
+annotation:
 	Identifier (Assign expression)?;
 
-utype: 
+utype:
 	(UClass | UStruct) LeftParen annotationList? RightParen;
 
 uproperty:
@@ -57,7 +57,7 @@ moduleImport:
 
 asGeneric:
 	Identifier Less simpleTypeSpecifierList Greater;
-	
+
 simpleTypeSpecifierList:
 	declSpecifierSeq (Comma declSpecifierSeq)*;
 
@@ -300,7 +300,7 @@ emptyDeclaration: Semi;
 declSpecifier:
 	typeSpecifier
 	| functionSpecifier;
-	
+
 declSpecifierSeq: declSpecifier+?;
 
 functionSpecifier: Virtual;
@@ -338,6 +338,8 @@ simpleTypeSpecifier:
 	| UInt32
 	| UInt64
 	| Float
+	| Float32
+	| Float64
 	| Double
 	| Bool
 	| Void


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The exciser currently generates e.g.
```
        float32 CalcActions(const TArray<float32>& Actions)
        {
#ifdef WITH_SERVER
                const int Len = Actions.Num();
                float32 SumOfSquares = 0.0f;
                for (int i = 0; i < Len; i++)
                {
                        const float32 Action = Actions[i];
                        SumOfSquares += (Action*Action);
                }
                return FMath::Sqrt(SumOfSquares / float32(Len));
#else
                return nullptr;
#endif // WITH_SERVER
        }
```
which is wrong, it should return 0.

### Related Issues


