### PR TITLE
Add support for access specifiers

### DIFF
--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
@@ -80,6 +80,8 @@ Bool: 'bool';
 
 Auto: 'auto';
 
+Access: 'access';
+
 Break: 'break';
 
 Case: 'case';
@@ -98,6 +100,8 @@ Default: 'default';
 
 Do: 'do';
 
+EditDefaults: 'editdefaults';
+
 Else: 'else';
 
 Enum: 'enum';
@@ -114,6 +118,8 @@ Goto: 'goto';
 
 If: 'if';
 
+Inherited: 'inherited';
+
 Namespace: 'namespace';
 
 Nullptr: 'nullptr';
@@ -127,6 +133,8 @@ Private: 'private';
 Protected: 'protected';
 
 Public: 'public';
+
+ReadOnly: 'readonly';
 
 Return: 'return';
 

--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
@@ -444,7 +444,7 @@ parameterDeclaration:
 	declSpecifierSeq Identifier? (Assign initializerClause)?;
 
 functionDefinition:
-	ufunction? accessSpecifier? Mixin? declSpecifierSeq? declarator postFuncSpecifierSeq? functionBody;
+	ufunction? (accessSpecifier | accessPattern)? Mixin? declSpecifierSeq? declarator postFuncSpecifierSeq? functionBody;
 
 functionBody:
 	compoundStatement
@@ -491,10 +491,11 @@ memberdeclaration:
 	propertyDefinition
 	| functionDefinition
 	| aliasDeclaration
-	| emptyDeclaration;
+	| emptyDeclaration
+	| accessDeclaration;
 
 propertyDefinition:
-	uproperty? accessSpecifier? Default? declSpecifierSeq? (memberDeclaratorList | assignmentExpression)? Semi;
+	uproperty? (accessSpecifier | accessPattern)? Default? declSpecifierSeq? (memberDeclaratorList | assignmentExpression)? Semi;
 
 memberDeclaratorList:
 	memberDeclarator (Comma memberDeclarator)*;
@@ -531,6 +532,14 @@ classOrDeclType:
 baseTypeSpecifier: classOrDeclType;
 
 accessSpecifier: Private | Protected | Public;
+
+accessModifier: Inherited | EditDefaults | ReadOnly;
+
+accessModifiers: LeftParen accessModifier (Comma accessModifier)* RightParen;
+
+accessDeclaration: Access Identifier Assign accessSpecifier ((Comma Identifier accessModifiers?)* | (Comma Star accessModifiers)) Semi;
+
+accessPattern: Access Colon Identifier;
 
 /*Overloading*/
 


### PR DESCRIPTION
### Description of Changes

Add support for access specifiers. This PR evolves the Angelscript grammar to properly parse files with access specifier declarations. The grammar improvements were created to adhere to all the new syntax found in the file `Example_AccessSpecifier.as`.

### Example_AccessSpecifier.as

```
/**
 * Access specifiers give more granular control over which
 * other classes can use specific functions and variables.
 * 
 * This allows a component to only allow certain capabilities
 * to call functions on it, for example.
 */
class UAccessSpecifierExample
{
	// Access specifiers need to be declared in the class they are used in
	// All access specifiers start with private or protected as a base.
	access Internal = private;

	// This would be equivalent to `private`
	access:Internal
	float PrivateFloatValue = 0.0;



	// From there, you can add a list of classes that should also be granted access
	// on top of the private or protected access.
	access InternalWithCapability = private, UAccessSpecifierComponent, APlayerController;

	// This can be accessed as private, or by etiher of the two classes specified above
	access:InternalWithCapability
	float AccessibleFloatValue = 1.0;

	// Functions can also use access specifiers
	access:InternalWithCapability
	void AccessibleMethod()
	{
	}


	// It is also possible to restrict the type of access that a particular class
	// gets, using modifiers. Available modifiers are:
	//
	// editdefaults:
	//	The class can only set the property or call the function from a `default` statement or a ConstructionScript.
	// 
	// readonly:
	//  The class can only read properties or call const methods, not do anything that can modify it.
	//
	access SpecifierCapabilityCanOnlyRead = private, UAccessSpecifierComponent (readonly);

	// This can be read from UAccessSpecifierCapability, but not changed
	access:SpecifierCapabilityCanOnlyRead
	float CapabilityReadOnlyValue = 0.0;



	// Normally, when specifying a class, only that specific class has access, not its children.
	// With the `inherited` modifier, you can give all child classes of the specified class the same access.
	access ReadableInAnySceneComponent = private, USceneComponent (inherited, readonly);

	// This value is private, but can be read (not written) from capabilities only
	access:ReadableInAnySceneComponent
	float CanBeReadBySceneComponents = 10.0;



	// Instead of writing a class name you can specify just `*` to give access to all classes.
	// This should be used in combination with modifiers.
	access EditAndReadOnly = private, * (editdefaults, readonly);

	// This value is read-only outside this class, but can be edited from `default` statements by any class
	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Options")
	access:EditAndReadOnly
	bool bOptionOnlyEditable = false;



	// Global functions can also be given access just like classes
	//  Note that neither classes nor functions need to be imported to be given access
	access RestrictedToSpecificGlobalFunction = private, ExampleCallRestrictedFunction;

	access:RestrictedToSpecificGlobalFunction
	void RestrictedFunction()
	{
	}
};

void ExampleCallRestrictedFunction()
{
	UAccessSpecifierExample Example;
	Example.RestrictedFunction();
}

class UAccessSpecifierComponent : UActorComponent
{
};
```