### PR TITLE
Allow multiple variables assignment in single line declaration

### DIFF
--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
@@ -495,7 +495,10 @@ memberdeclaration:
 	| accessDeclaration;
 
 propertyDefinition:
-	uproperty? (accessSpecifier | accessPattern)? Default? declSpecifierSeq? (memberDeclaratorList | assignmentExpression)? Semi;
+	uproperty? (accessSpecifier | accessPattern)? Default? declSpecifierSeq? (memberDeclaratorList | assignmentList)? Semi;
+
+assignmentList:
+	assignmentExpression (Comma assignmentExpression)*;
 
 memberDeclaratorList:
 	memberDeclarator (Comma memberDeclarator)*;


### PR DESCRIPTION
### Description of Changes

Improve Angelscript grammar to allow assignation of multiple variables in a single line.

### Example

```
...
	private const int CONSTANT_VAR1 = 0, CONSTANT_VAR2 = 1, CONSTANT_VAR3 = 2;
...
```
