### PR TITLE
Add support for UENUM annotations

### DIFF
--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
@@ -44,6 +44,8 @@ UProperty: 'UPROPERTY';
 
 UFunction: 'UFUNCTION';
 
+UEnum: 'UENUM';
+
 Import: 'import';
 
 From: 'from';

--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
@@ -42,7 +42,7 @@ annotation:
 	Identifier (Assign expression)?;
 
 utype:
-	(UClass | UStruct) LeftParen annotationList? RightParen;
+	(UClass | UStruct | UEnum) LeftParen annotationList? RightParen;
 
 uproperty:
 	UProperty LeftParen annotationList? RightParen;
@@ -367,10 +367,10 @@ enumSpecifier:
 	enumHead LeftBrace (enumeratorList Comma?)? RightBrace Semi?;
 
 enumHead:
-	enumkey (nestedNameSpecifier? Identifier)? enumbase?;
+	utype? enumkey (nestedNameSpecifier? Identifier)? enumbase?;
 
 opaqueEnumDeclaration:
-	enumkey Identifier enumbase? Semi;
+	utype? enumkey Identifier enumbase? Semi;
 
 enumkey: Enum;
 

--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
@@ -41,8 +41,11 @@ annotationList:
 annotation:
 	Identifier (Assign expression)?;
 
+uenum:
+	UEnum LeftParen annotationList? RightParen;
+
 utype:
-	(UClass | UStruct | UEnum) LeftParen annotationList? RightParen;
+	(UClass | UStruct) LeftParen annotationList? RightParen;
 
 uproperty:
 	UProperty LeftParen annotationList? RightParen;
@@ -367,10 +370,10 @@ enumSpecifier:
 	enumHead LeftBrace (enumeratorList Comma?)? RightBrace Semi?;
 
 enumHead:
-	utype? enumkey (nestedNameSpecifier? Identifier)? enumbase?;
+	uenum? enumkey (nestedNameSpecifier? Identifier)? enumbase?;
 
 opaqueEnumDeclaration:
-	utype? enumkey Identifier enumbase? Semi;
+	uenum? enumkey Identifier enumbase? Semi;
 
 enumkey: Enum;
 


### PR DESCRIPTION
### Description of Changes

Add support for UENUM annotations.

### Example

```
UENUM(meta = (BitFlags))
enum ENameFlags
{
  FLAG0 = 0,
  FLAG1 = 1 << 0,
  FLAV2 = 1 << 1,
  FLAG3 = 1 << 2
}
```