### PR TITLE
Improve detection of already compliant code

### DIFF
--- a/ServerCodeExciser/ServerCodeExcisionProcessor.cs
+++ b/ServerCodeExciser/ServerCodeExcisionProcessor.cs
@@ -215,6 +215,7 @@ namespace ServerCodeExcision
                     if (currentScope.StartIndex == -1
                         || currentScope.StopIndex == -1
                         || InjectedMacroAlreadyExistsAtLocation(answerText, currentScope.StartIndex, true, excisionLanguage.ServerScopeStartString)
+                        || InjectedMacroAlreadyExistsAtLocation(answerText, currentScope.StartIndex, false, excisionLanguage.ServerScopeStartString)
                         || InjectedMacroAlreadyExistsAtLocation(answerText, currentScope.StopIndex, false, excisionLanguage.ServerScopeEndString))
                     {
                         continue;

--- a/ServerCodeExciser/ServerCodeExcisionProcessor.cs
+++ b/ServerCodeExciser/ServerCodeExcisionProcessor.cs
@@ -230,13 +230,21 @@ namespace ServerCodeExcision
                 // Next we must add dummy reference variables if they exist.
                 foreach (KeyValuePair<int, HashSet<string>> dummyRefDataPair in visitor.ClassStartIdxDummyReferenceData)
                 {
-                    var dummyRefDataBlockString = new StringBuilder("#ifndef " + excisionLanguage.ServerPrecompilerSymbol);
+                    var dummyRefDataBlockString = new StringBuilder();
+                    var dummyVarScope = "#ifndef " + excisionLanguage.ServerPrecompilerSymbol;
+                    dummyRefDataBlockString.Append(dummyVarScope);
                     foreach (var dummyVarDef in dummyRefDataPair.Value)
                     {
                         dummyRefDataBlockString.Append("\r\n\t" + dummyVarDef);
                     }
 
                     dummyRefDataBlockString.Append("\r\n" + excisionLanguage.ServerScopeEndString + "\r\n");
+
+                    // If there is already a block of dummy reference variables we skip adding new ones, there is no guarantee we are adding the right code.
+                    if (InjectedMacroAlreadyExistsAtLocation(answerText, dummyRefDataPair.Key, false, dummyVarScope + "\r\n"))
+                    {
+                        continue;
+                    }
 
                     serverCodeInjections.Add(new KeyValuePair<int, string>(dummyRefDataPair.Key, dummyRefDataBlockString.ToString()));
                 }


### PR DESCRIPTION
### Description of Changes

Attempt to make the code exciser idempotent. We are transitioning to use it as a validator, but that won't be possible if the transformed code is not stable.

If we have already created a block for dummy vars we end up nesting them inside a chain of `ifndef`.

A dummy var reference is used when the code exciser needs to return data when providing an alternative path for a non server return.

This fix avoids:
- nesting non needed dummy vars if the `ifndef` block is already found.
- nesting `else if` blocks inside `#ifdef` blocks.

### Example

```
#ifndef WITH_SERVER
#ifndef WITH_SERVER
  FData FDataReferenceDummy0;
#endif // WITH_SERVER

  FDData FDataReferenceDummy2;
#endif // WITH_SERVER

...

if (System::IsServer())
{
#ifdef WITH_SERVER
  return LatestData;
#else
  return FDeflectServiceDataReferenceDummy2;
#endif // WITH_SERVER
}
```

```
if (!System::IsServer())
{
  ...
}
#ifdef WITH_SERVER
else if (...)
{
  ...
}
#else
{
}
#endif // WITH_SERVER
```