### PR TITLE
Allow empty lines at the beginning of a server scope

### DIFF
--- a/ServerCodeExcisionCommon/ServerCodeExcisionUtils.cs
+++ b/ServerCodeExcisionCommon/ServerCodeExcisionUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using Antlr4.Runtime;
 
 namespace ServerCodeExcisionCommon
@@ -110,6 +111,7 @@ namespace ServerCodeExcisionCommon
 	public static class ExcisionUtils
 	{
 		private static char[] NewLineChars = { '\r', '\n' };
+		private static char[] SkippableScopeChars = { '\t', '\r', '\n' };
 
 		public static int FindScriptIndexForCodePoint(string script, int line, int column)
 		{
@@ -139,6 +141,24 @@ namespace ServerCodeExcisionCommon
 			}
 
 			return (linesTraversed == line) ? (cursor + column) : -1;
+		}
+
+		public static int ShrinkServerScope(string script, int start, int end)
+		{
+			bool skip = true;
+			while (skip)
+			{
+				skip = false;
+
+				int search = script.IndexOfAny(NewLineChars, start) + 2;
+				if ((search < end) && SkippableScopeChars.Contains<char>(script.ElementAt(search)))
+				{
+					skip = true;
+					++start;
+				}
+			}
+
+			return start;
 		}
 
 		public static Type FindFirstDirectChildOfType<Type>(Antlr4.Runtime.Tree.IParseTree currentContext)

--- a/UnrealAngelscriptServerCodeExcision/UnrealAngelscriptSymbolVisitor.cs
+++ b/UnrealAngelscriptServerCodeExcision/UnrealAngelscriptSymbolVisitor.cs
@@ -263,6 +263,10 @@ namespace UnrealAngelscriptServerCodeExcision
 							ExcisionUtils.FindScriptIndexForCodePoint(Script, simpleDeclaration.Stop.Line, simpleDeclaration.Stop.Column) + 1,
 							ExcisionUtils.FindScriptIndexForCodePoint(Script, parentScope.Stop.Line, 0));
 
+						// We need to correct the start index to skip all the possible empty characters/new lines,
+						// if not we can miss the detection of a manually placed #ifdef
+						newData.StartIndex = ExcisionUtils.ShrinkServerScope(Script, newData.StartIndex, newData.StopIndex);
+
 						if (returnData.ReturnType != EReturnType.NoReturn)
 						{
 							string scopeIndentation = BuildIndentationForColumnCount(simpleDeclaration.Start.Column);


### PR DESCRIPTION
Developers are having problems if they don't place the `ifdef` right after the `check(System::IsServer())`, as the server scope is compared starting after the check and we fail to detect that the server scope is already protected.

```
	UFUNCTION(BlueprintOverride)
	void Tick(float DeltaSeconds)
	{
		FTraceScope TraceScope(n"UGaitGroundContactHelperComponent::Tick");
		check(System::IsServer());

#ifdef WITH_SERVER
		GroundContactHitResults.Empty();
#endif
	}
```

Build [Discovery](https://buildkite.com/embark-studios/discovery-submit-attempt/builds/62671#0194f072-c7a7-44ae-badd-4b87a100337c).
Build [Pioneer](https://buildkite.com/embark-studios/pioneer-submit-attempt/builds/47785#0194f073-6b5f-48d5-9dce-a5431055adf2).