### PR TITLE
Allow UMETA decorator for enumerations

### DIFF
--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
@@ -46,6 +46,8 @@ UFunction: 'UFUNCTION';
 
 UEnum: 'UENUM';
 
+UMeta: 'UMETA';
+
 Import: 'import';
 
 From: 'from';

--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
@@ -44,6 +44,9 @@ annotation:
 uenum:
 	UEnum LeftParen annotationList? RightParen;
 
+umeta:
+	UMeta LeftParen annotationList? RightParen;
+
 utype:
 	(UClass | UStruct) LeftParen annotationList? RightParen;
 
@@ -382,7 +385,7 @@ enumbase: Colon typeSpecifierSeq;
 enumeratorList:
 	enumeratorDefinition (Comma enumeratorDefinition)*;
 
-enumeratorDefinition: enumerator (Assign constantExpression)?;
+enumeratorDefinition: enumerator (Assign constantExpression)? umeta?;
 
 enumerator: Identifier;
 


### PR DESCRIPTION
Allow UMETA decorator for enumerations.

The annotations list is not strict. We will leave that check for the AS compiler.