### PR TITLE
Allow trailing comma in parameter list

### DIFF
--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
@@ -445,7 +445,7 @@ theTypeId: typeSpecifierSeq;
 parameterDeclarationClause:	parameterDeclarationList;
 
 parameterDeclarationList:
-	parameterDeclaration (Comma parameterDeclaration)*;
+	parameterDeclaration (Comma parameterDeclaration )* Comma?;
 
 parameterDeclaration:
 	declSpecifierSeq Identifier? (Assign initializerClause)?;

--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
@@ -445,7 +445,7 @@ theTypeId: typeSpecifierSeq;
 parameterDeclarationClause:	parameterDeclarationList;
 
 parameterDeclarationList:
-	parameterDeclaration (Comma parameterDeclaration )* Comma?;
+	parameterDeclaration (Comma parameterDeclaration)* Comma?;
 
 parameterDeclaration:
 	declSpecifierSeq Identifier? (Assign initializerClause)?;


### PR DESCRIPTION
Trailing commas were already allowed in enums, but it seems we need to allow them also in parameters lists.

Developers are using this already.
