### PR TITLE
Allow no discard attribute

### DIFF
--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
@@ -128,6 +128,8 @@ Inherited: 'inherited';
 
 Namespace: 'namespace';
 
+NoDiscard: 'no_discard';
+
 Nullptr: 'nullptr';
 
 Operator: 'operator';

--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
@@ -432,7 +432,7 @@ declaratorDef:
 	declaratorid | declaratorDef (parametersAndQualifiers | LeftBracket constantExpression? RightBracket);
 
 parametersAndQualifiers:
-	LeftParen parameterDeclarationClause? RightParen thisModifier? refqualifier?;
+	LeftParen parameterDeclarationClause? RightParen thisModifier? refqualifier? NoDiscard?;
 
 thisModifier: Const | AcceptTemporaryThis;
 


### PR DESCRIPTION
Developers are starting to use the `no_discard` attribute to force the handling of the returned value.
