### PR TITLE
Support unicode bytes in string literals.

### DIFF
--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptParser.g4
@@ -21,9 +21,9 @@
  */
 
 /*
-	Adapted to Unreal Angelscript by Embark Studios AB (Fredrik Lindh [Temaran]).
-	Based on the C++ grammar made by Camilo Sanchez (Camiloasc1) and Martin Mirchev (Marti2203). See the parser file.
- */
+	Adapted to Unreal Angelscript by Embark Studios AB (originally Fredrik Lindh [Temaran]).
+	Based on: https://github.com/antlr/grammars-v4/blob/master/cpp/CPP14Parser.g4
+*/
 
 parser grammar UnrealAngelscriptParser;
 options {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

- Support for unicode bytes in string literals; i.e. `f"Angle: {Angle:0.1f}\u00B0"`.
