### PR TITLE
Support preprocessor directives for server-code scopes.

### DIFF
--- a/ServerCodeExciserTest/Problems/Common/AlreadyHasGuardsTest.common
+++ b/ServerCodeExciserTest/Problems/Common/AlreadyHasGuardsTest.common
@@ -2,6 +2,10 @@ class UAlreadyHasGuardsTest
 {
 	void Test()
 	{
+// Commented out block.
+//#ifdef WITH_SERVER
+//#endif
+
 		int SomethingBefore = 0;
 		SomethingBefore++;
 
@@ -15,5 +19,36 @@ class UAlreadyHasGuardsTest
 
 		int ButNotThis = 0;
 		ButNotThis++;
+	}
+
+	void Test2()
+	{
+#ifdef WITH_SERVER
+		check(System::IsServer());
+		int ThisMustBeGuarded = 0;
+		ThisMustBeGuarded++;
+#endif // WITH_SERVER
+	}
+
+	void Test3()
+	{
+		check(System::IsServer());
+
+#ifdef WITH_SERVER
+		int ThisMustBeGuarded = 0;
+		ThisMustBeGuarded++;
+#endif
+	}
+
+	void Test4()
+	{
+		check(System::IsServer());
+#ifdef WITH_SERVER
+
+#if !RELEASE
+		int ThisMustBeGuarded = 0;
+		ThisMustBeGuarded++;
+#endif
+#endif
 	}
 };

--- a/ServerCodeExciserTest/Problems/Common/AlreadyHasGuardsTest.common.solution
+++ b/ServerCodeExciserTest/Problems/Common/AlreadyHasGuardsTest.common.solution
@@ -2,6 +2,10 @@ class UAlreadyHasGuardsTest
 {
 	void Test()
 	{
+// Commented out block.
+//#ifdef WITH_SERVER
+//#endif
+
 		int SomethingBefore = 0;
 		SomethingBefore++;
 
@@ -15,5 +19,36 @@ class UAlreadyHasGuardsTest
 
 		int ButNotThis = 0;
 		ButNotThis++;
+	}
+
+	void Test2()
+	{
+#ifdef WITH_SERVER
+		check(System::IsServer());
+		int ThisMustBeGuarded = 0;
+		ThisMustBeGuarded++;
+#endif // WITH_SERVER
+	}
+
+	void Test3()
+	{
+		check(System::IsServer());
+
+#ifdef WITH_SERVER
+		int ThisMustBeGuarded = 0;
+		ThisMustBeGuarded++;
+#endif
+	}
+
+	void Test4()
+	{
+		check(System::IsServer());
+#ifdef WITH_SERVER
+
+#if !RELEASE
+		int ThisMustBeGuarded = 0;
+		ThisMustBeGuarded++;
+#endif
+#endif
 	}
 };

--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
@@ -45,6 +45,8 @@ Directive: '#' ~ [\r\n]* -> channel (PREPROCESSOR_CHANNEL);
 
 Cast: 'cast';
 
+From: 'from';
+
 Import: 'import';
 
 Int: 'int';
@@ -58,6 +60,8 @@ Int32: 'int32';
 Int64: 'int64';
 
 Mixin: 'mixin';
+
+Out: 'out';
 
 Property: 'property';
 

--- a/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
+++ b/UnrealAngelscriptParser/Grammar/UnrealAngelscriptLexer.g4
@@ -5,6 +5,8 @@
 
 lexer grammar UnrealAngelscriptLexer;
 
+channels { PREPROCESSOR_CHANNEL }
+
 IntegerLiteral:
 	DecimalLiteral Integersuffix?
 	| OctalLiteral Integersuffix?
@@ -31,6 +33,10 @@ UserDefinedLiteral:
 	| UserDefinedFloatingLiteral
 	| UserDefinedStringLiteral
 	| UserDefinedCharacterLiteral;
+
+MultiLineMacro: '#' (~[\n]*? '\\' '\r'? '\n')+ ~ [\n]+ -> channel (PREPROCESSOR_CHANNEL);
+
+Directive: '#' ~ [\r\n]* -> channel (PREPROCESSOR_CHANNEL);
 
 /*
 	Angelscript reserved keywords
@@ -379,7 +385,3 @@ Newline: ('\r' '\n'? | '\n') -> skip;
 BlockComment: '/*' .*? '*/' -> skip;
 
 LineComment: '//' ~ [\r\n]* -> skip;
-
-PreprocessorBranchRemoval: '#else' .*? '#endif' -> skip;
-
-Preprocessor: ('#if' | '#ifdef' | '#else' | '#endif') ~ [\r\n]* -> skip;


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

- Support parsing of preprocessor directives using a self-contained `PREPROCESSOR` channel.
- Simplify identification of existing server-only scopes (`#ifdef WITH_SERVER`) to prevent injection of duplicate guards.
- Interestingly, this is a similar approach to that proposed by #15.

