### PR TITLE
Assorted codebase fixes

### DIFF
--- a/ServerCodeExciser/ServerCodeExciser.cs
+++ b/ServerCodeExciser/ServerCodeExciser.cs
@@ -9,7 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using UnrealAngelscriptServerCodeExcision;
 
-namespace ServerCodeExcision
+namespace ServerCodeExciser
 {
     internal sealed class ServerCodeExciserCommand : Command<ServerCodeExciserCommand.Settings>
     {

--- a/ServerCodeExciser/ServerCodeExciser.cs
+++ b/ServerCodeExciser/ServerCodeExciser.cs
@@ -61,19 +61,9 @@ namespace ServerCodeExcision
             [Description("Ensure that all files can be analyzed without syntactic or lexicographical errors.")]
             public bool StrictMode { get; init; }
 
-            [CommandArgument(0, "[INPUT]")]
+            [CommandArgument(0, "<INPUT_PATH>")]
             [Description("The input folder to excise.")]
-            public string InputPath { get; init; } = string.Empty;
-
-            public override ValidationResult Validate()
-            {
-                if (InputPath.Length <= 0)
-                {
-                    return ValidationResult.Error("Must provide at least one input path!");
-                }
-
-                return base.Validate();
-            }
+            public string? InputPath { get; init; }
         }
 
         class RootPaths
@@ -113,7 +103,7 @@ namespace ServerCodeExcision
                     return (int)EExciserReturnValues.InternalExcisionError;
                 }
             }
-            else if(Directory.Exists(settings.InputPath))
+            else if (Directory.Exists(settings.InputPath))
             {
                 parameters.InputPaths.Add(settings.InputPath);
             }
@@ -152,14 +142,7 @@ namespace ServerCodeExcision
     {
         public static int Main(string[] args)
         {
-            if (args.Length < 1)
-            {
-                Console.Error.WriteLine("You must provide an input path to read input files from as the first argument.");
-                return (int)EExciserReturnValues.BadInputPath;
-            }
-
-            var app = new CommandApp<ServerCodeExciserCommand>();
-            return app.Run(args);
+            return new CommandApp<ServerCodeExciserCommand>().Run(args);
         }
     }
 }

--- a/ServerCodeExciser/ServerCodeExciser.cs
+++ b/ServerCodeExciser/ServerCodeExciser.cs
@@ -28,9 +28,9 @@ namespace ServerCodeExciser
 
             [CommandOption("-f|--fullyexcise <REGEX>")]
             [Description("If this switch is specified, the next argument should be a string containing regex entries." +
-                            "If any of these regexes matches the relative path of any file to be processed, the entire file will be excised." +
-                            "You can specify more than one entry by separating them with three pipes, eg: " +
-                            "Characters /Paul/.*|||Weapons/Rife.as")]
+                "If any of these regexes matches the relative path of any file to be processed, the entire file will be excised." +
+                "You can specify more than one entry by separating them with three pipes, eg: " +
+                "Characters/Paul/.*|||Weapons/Rife.as")]
             public string? FullExcisionRegexString { get; init; }
 
             [CommandOption("-s|--dontskip")]

--- a/ServerCodeExciser/ServerCodeExciser.cs
+++ b/ServerCodeExciser/ServerCodeExciser.cs
@@ -39,7 +39,7 @@ namespace ServerCodeExciser
 
             [CommandOption("-m|--minratio")]
             [Description("Specify a ratio in percent as the next argument. If the excised % of code is less than this ratio, an error will be thrown. Good to detect catastrophic changes in excision performance.")]
-            public int? RequiredExcisionRatio { get; init; } = -1;
+            public int RequiredExcisionRatio { get; init; } = 0;
 
             [CommandOption("-t|--funcstats")]
             [Description("Outputs function stats instead of file stats. This is more accurate, but a lot slower, since it has to parse every file.")]
@@ -84,10 +84,7 @@ namespace ServerCodeExciser
             parameters.StrictMode = settings.StrictMode;
             parameters.UseFunctionStats = settings.UseFunctionStats;
             parameters.DontSkip = settings.DontSkip;
-            if (settings.RequiredExcisionRatio.HasValue)
-            {
-                parameters.RequiredExcisionRatio = settings.RequiredExcisionRatio.Value / 100.0f;
-            }
+            parameters.RequiredExcisionRatio = settings.RequiredExcisionRatio / 100.0f;
 
             if (File.Exists(settings.InputPath))
             {

--- a/ServerCodeExciser/ServerCodeExcisionProcessor.cs
+++ b/ServerCodeExciser/ServerCodeExcisionProcessor.cs
@@ -37,7 +37,7 @@ namespace ServerCodeExciser
             _parameters = parameters;
 
             _functionExciseRegexes = new List<Regex>();
-            if (_parameters.ExciseAllFunctionsRegexString != "")
+            if (!string.IsNullOrEmpty(_parameters.ExciseAllFunctionsRegexString))
             {
                 var allFunctionExciseRegexStrings = _parameters.ExciseAllFunctionsRegexString.Split("|||");
                 foreach (var regexString in allFunctionExciseRegexStrings)
@@ -48,7 +48,7 @@ namespace ServerCodeExciser
             }
 
             _fullyExciseRegexes = new List<Regex>();
-            if (_parameters.FullExcisionRegexString != "")
+            if (!string.IsNullOrEmpty(_parameters.FullExcisionRegexString))
             {
                 var fullyExciseRegexStrings = _parameters.FullExcisionRegexString.Split("|||");
                 foreach (var regexString in fullyExciseRegexStrings)

--- a/ServerCodeExciser/ServerCodeExcisionProcessor.cs
+++ b/ServerCodeExciser/ServerCodeExcisionProcessor.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace ServerCodeExcision
+namespace ServerCodeExciser
 {
     public class ServerCodeExcisionParameters
     {

--- a/ServerCodeExciser/ServerCodeExcisionProcessor.cs
+++ b/ServerCodeExciser/ServerCodeExcisionProcessor.cs
@@ -22,7 +22,7 @@ namespace ServerCodeExciser
         public bool StrictMode { get; set; } = false;
         public bool UseFunctionStats { get; set; } = false;
         public bool DontSkip { get; set; } = false;
-        public float RequiredExcisionRatio { get; set; } = -1.0f;
+        public float RequiredExcisionRatio { get; set; } = 0.0f;
         public EExcisionLanguage ExcisionLanguage { get; set; } = EExcisionLanguage.Unknown;
     }
 

--- a/ServerCodeExciser/ServerCodeExcisionProcessor.cs
+++ b/ServerCodeExciser/ServerCodeExcisionProcessor.cs
@@ -1,8 +1,8 @@
 using Antlr4.Runtime;
 using ServerCodeExcisionCommon;
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -61,7 +61,7 @@ namespace ServerCodeExciser
 
         public EExciserReturnValues ExciseServerCode(string filePattern, IServerCodeExcisionLanguage excisionLanguage)
         {
-            var startTime = DateTime.UtcNow;
+            var globalStopwatch = Stopwatch.StartNew();
             var globalStats = new ExcisionStats();
 
             var options = new EnumerationOptions();
@@ -107,16 +107,19 @@ namespace ServerCodeExciser
 
                     try
                     {
+                        var stopwatch = Stopwatch.StartNew();
                         var stats = ProcessCodeFile(fileName, inputPath, excisionMode, excisionLanguage);
+                        stopwatch.Stop();
+
                         if (stats.CharactersExcised > 0)
                         {
                             System.Diagnostics.Debug.Assert(stats.TotalNrCharacters > 0, "Something is terribly wrong. We have excised characters, but no total characters..?");
                             var excisionRatio = (float)stats.CharactersExcised / (float)stats.TotalNrCharacters * 100.0f;
-                            Console.WriteLine("Excised {0:0.00}% of server only code in file ({1}/{2}): {3}", excisionRatio, fileIdx + 1, allFiles.Length, fileName);
+                            Console.WriteLine($"[{fileIdx + 1}/{allFiles.Length}] Excised {excisionRatio:0.00}% of server only code in file (took {stopwatch.Elapsed.TotalMilliseconds:0.0}ms): {fileName}");
                         }
                         else
                         {
-                            Console.WriteLine("No server only code found in file ({0}/{1}): {2}", fileIdx + 1, allFiles.Length, fileName);
+                            Console.WriteLine($"[{fileIdx + 1}/{allFiles.Length}] No server only code found in file: {fileName}");
                         }
 
                         globalStats.CharactersExcised += stats.CharactersExcised;
@@ -124,13 +127,13 @@ namespace ServerCodeExciser
                     }
                     catch (Exception)
                     {
-                        Console.WriteLine("Failed to parse ({0}/{1}): {2}", fileIdx + 1, allFiles.Length, fileName);
+                        Console.Error.WriteLine($"[{fileIdx + 1}/{allFiles.Length}] Failed to parse: {fileName}");
                         throw;
                     }
                 }
             }
 
-            var endTime = DateTime.UtcNow;
+            globalStopwatch.Stop();
 
             // In verification mode error codes reverse the normal behavior of the exciser.
             // Modifications required -> error
@@ -157,8 +160,7 @@ namespace ServerCodeExciser
                 Console.WriteLine("Excised {0:0.00}% ({1}/{2} characters) of server only code from the script files.",
                             totalExcisionRatio, globalStats.CharactersExcised, globalStats.TotalNrCharacters);
 
-                var timeTaken = endTime - startTime;
-                Console.WriteLine("Excision took {0:0} hours, {1:0} minutes and {2:0.0} seconds.\n\n", timeTaken.Hours, timeTaken.Minutes, timeTaken.Seconds);
+                Console.WriteLine($"Excision took {globalStopwatch.Elapsed.TotalSeconds:0.0}s.");
 
                 if (_parameters.RequiredExcisionRatio > 0.0f && totalExcisionRatio < _parameters.RequiredExcisionRatio)
                 {

--- a/ServerCodeExciserTest/ExcisionIntegrationTests.cs
+++ b/ServerCodeExciserTest/ExcisionIntegrationTests.cs
@@ -1,4 +1,4 @@
-using ServerCodeExcision;
+using ServerCodeExciser;
 using ServerCodeExcisionCommon;
 using Spectre.Console;
 using System;


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

- Add source-level process timings; i.e. "how long did a specific file take to excise?" rather than purely global runtime.
- Remove custom CLI input path validation; `Spectre.Console.Cli` can do this via `<INPUT_PATH>` (angled bracket) syntax.
- Fix instance where namespace did not match project name.
- Fix confusing type casting when calculating "required excision ratio" from CLI percentage.